### PR TITLE
Fix color in fill() and add support for multiple pages

### DIFF
--- a/components/crowpanel_epaper/crowpanel_epaper.cpp
+++ b/components/crowpanel_epaper/crowpanel_epaper.cpp
@@ -456,8 +456,8 @@ int CrowPanelEPaper::get_height_internal() {
 }
 
 void CrowPanelEPaper::fill(Color color) {
-  const uint8_t fill = !color.is_on() ? 0x00 : 0xFF;
-  ESP_LOGD(TAG, "Filling buffer with %s", !color.is_on() ? "BLACK" : "WHITE");
+  const uint8_t fill = color.is_on() ? 0x00 : 0xFF;
+  ESP_LOGD(TAG, "Filling buffer with %s", color.is_on() ? "BLACK" : "WHITE");
   
   if (this->get_buffer_length_() == 0 || this->buffer_ == nullptr) {
     ESP_LOGE(TAG, "ERROR: Buffer not initialized");

--- a/components/crowpanel_epaper/crowpanel_epaper.cpp
+++ b/components/crowpanel_epaper/crowpanel_epaper.cpp
@@ -314,7 +314,9 @@ void CrowPanelEPaperBase::loop() {
       this->fill(display::COLOR_OFF);
       
       // Execute the lambda (if set) - this draws text, shapes, etc.
-      if (this->writer_.has_value()) {
+      if (this->page_ != nullptr) {
+        this->page_->get_writer()(*this);
+      } else if (this->writer_.has_value()) {
         (*this->writer_)(*this);
       }
       


### PR DESCRIPTION
While rebasing my 5.79in changes I noticed that I forgot to include a change in my previous PR #3 related to the fill function. Without it, the panel goes fully black instead of white :D

I'm hoping to finish with the 5.79in integration today.
